### PR TITLE
Minimimum library dependencies & reorder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,11 @@ lazy val core = project
   .settings(Defaults.itSettings)
   .configs(IntegrationTest)
   .settings(libraryDependencies ++= Seq(
-    "org.specs2"        %% "specs2-cats"           % specs2V               % IntegrationTest,
-    "org.tpolecat"      %% "doobie-core"           % doobieV               % IntegrationTest,
-    "org.tpolecat"      %% "doobie-postgres"       % doobieV               % IntegrationTest,
+    "org.scala-lang"    % "scala-reflect"          % scalaVersion.value,
+    "io.chrisdavenport" %% "fuuid-doobie"          % fuuidV % IntegrationTest,
+    "org.specs2"        %% "specs2-cats"           % specs2V % IntegrationTest,
+    "org.tpolecat"      %% "doobie-core"           % doobieV % IntegrationTest,
+    "org.tpolecat"      %% "doobie-postgres"       % doobieV % IntegrationTest,
     "io.chrisdavenport" %% "testcontainers-specs2" % testContainersSpecs2V % IntegrationTest
   ))
 
@@ -52,13 +54,10 @@ lazy val commonSettings = Seq(
   addCompilerPlugin("org.scalamacros" % "paradise"         % macroParadiseV cross CrossVersion.full),
   addCompilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerV),
   libraryDependencies ++= Seq(
-    "org.scala-lang"    % "scala-reflect"    % scalaVersion.value,
-    "org.tpolecat"      %% "doobie-postgres" % doobieV,
-    "com.github.ghik"   %% "silencer-lib"    % silencerV % Provided,
-    "io.chrisdavenport" %% "fuuid"           % fuuidV,
-    "io.chrisdavenport" %% "fuuid-doobie"    % fuuidV,
-    "org.specs2"        %% "specs2-core"     % specs2V % Test,
-    "org.specs2"        %% "specs2-cats"     % specs2V % Test
+    "com.github.ghik"   %% "silencer-lib" % silencerV % Provided,
+    "io.chrisdavenport" %% "fuuid"        % fuuidV,
+    "org.specs2"        %% "specs2-core"  % specs2V % Test,
+    "org.specs2"        %% "specs2-cats"  % specs2V % Test
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,10 @@ lazy val docs = project
   .dependsOn(core)
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(TutPlugin)
+  .settings(libraryDependencies ++= Seq(
+    "io.chrisdavenport" %% "fuuid-doobie"    % fuuidV,
+    "org.tpolecat"      %% "doobie-postgres" % doobieV,
+  ))
 
 lazy val contributors = Seq(
   "ChristopherDavenport" -> "Christopher Davenport",

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val core = project
   .configs(IntegrationTest)
   .settings(libraryDependencies ++= Seq(
     "org.scala-lang"    % "scala-reflect"          % scalaVersion.value,
+    "com.chuusai"       %% "shapeless"             % shapelessV % Test,
     "io.chrisdavenport" %% "fuuid-doobie"          % fuuidV % IntegrationTest,
     "org.specs2"        %% "specs2-cats"           % specs2V % IntegrationTest,
     "org.tpolecat"      %% "doobie-core"           % doobieV % IntegrationTest,
@@ -32,6 +33,7 @@ lazy val contributors = Seq(
 )
 
 val doobieV = "0.7.0"
+val shapelessV = "2.3.3"
 val fuuidV = "0.2.0"
 val specs2V = "4.5.1"
 val macroParadiseV = "2.1.1"

--- a/core/src/it/scala/io/chrisdavenport/fuuid/annotation/DeriveIdSpec.scala
+++ b/core/src/it/scala/io/chrisdavenport/fuuid/annotation/DeriveIdSpec.scala
@@ -42,6 +42,9 @@ class DeriveIdSpec extends Specification with ForAllTestContainer with IOMatcher
 
   "Meta[User.Id]" should {
 
+    import User._
+    import io.chrisdavenport.fuuid.doobie.implicits._
+
     "return User.Id on UUID" in {
       val uuid = UUID.randomUUID()
 

--- a/core/src/it/scala/io/chrisdavenport/fuuid/annotation/DeriveIdSpec.scala
+++ b/core/src/it/scala/io/chrisdavenport/fuuid/annotation/DeriveIdSpec.scala
@@ -42,7 +42,7 @@ class DeriveIdSpec extends Specification with ForAllTestContainer with IOMatcher
 
   "Meta[User.Id]" should {
 
-    import User._
+    import User.Id.implicits._
     import io.chrisdavenport.fuuid.doobie.implicits._
 
     "return User.Id on UUID" in {

--- a/core/src/test/scala/io/chrisdavenport/fuuid/annotation/DeriveIdSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/fuuid/annotation/DeriveIdSpec.scala
@@ -16,7 +16,7 @@ class DeriveIdSpec extends Specification with IOMatchers {
 
   "FUUID annotation" should {
 
-    import User._
+    import User.Id.implicits._
 
     val expected = Fuuid.fuuid("13ea2ea9-6e30-4160-8491-f8d900eadb8f")
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -66,6 +66,7 @@ You'll need to add the following dependencies to your `build.sbt`:
 ```scala
 libraryDependencies ++= Seq(
   "io.chrisdavenport" %% "fuuid"           % "<version>",
+  "io.chrisdavenport" %% "fuuid-doobie"    % "<version>",
   "org.tpolecat"      %% "doobie-postgres" % "<doobie-version>",
 )
 ```
@@ -76,3 +77,18 @@ Then, just set annotation's `deriveMeta` to `true`:
 @DeriveId(deriveMeta = true)
 object Person
 ``` 
+
+The `Meta[Id]` instance will be available under object `Person`. An implicit instance of `Meta[FUUID]` must be provided.
+
+> A `Meta[FUUID]` instance can be provided by importing both `doobie.postgres.implicits_` and `io.chrisdavenport.fuuid.doobie.implicits_`.
+
+```tut:silent
+import doobie.util.Meta
+import doobie.postgres.implicits._
+import io.chrisdavenport.fuuid.doobie.implicits._
+import Person._
+```
+
+```tut
+Meta[Person.Id]
+```

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -55,7 +55,7 @@ User.Id.random[IO]
 User.Id.Unsafe.random
 ```
 
-The annotation also provides instances for cats `Show`, `Order` and `Hash` (availables at `User._`)
+The annotation also provides instances for cats `Show`, `Order` and `Hash` (available under `User.Id.implicits`)
 
 ## Doobie integration
 
@@ -78,15 +78,15 @@ Then, just set annotation's `deriveMeta` to `true`:
 object Person
 ``` 
 
-The `Meta[Id]` instance will be available under object `Person`. An implicit instance of `Meta[FUUID]` must be provided.
+The `Meta[Id]` instance will be available under `Person.Id.implicits`. An implicit instance of `Meta[FUUID]` must be provided.
 
-> A `Meta[FUUID]` instance can be provided by importing both `doobie.postgres.implicits_` and `io.chrisdavenport.fuuid.doobie.implicits_`.
+> A `Meta[FUUID]` instance can be provided by importing both `doobie.postgres.implicits._` and `io.chrisdavenport.fuuid.doobie.implicits._`.
 
 ```tut:silent
 import doobie.util.Meta
 import doobie.postgres.implicits._
 import io.chrisdavenport.fuuid.doobie.implicits._
-import Person._
+import Person.Id.implicits._
 ```
 
 ```tut


### PR DESCRIPTION
# What has been done in this PR?

- Remove unneeded dependencies :)
- Change `Meta[Id]` to `def` depending on implicit `Meta[FUUID]`
- Move implicits under `Id.implicits` object
- Add example of `Meta[Id]` recovery